### PR TITLE
Fixes/image loading perf fix

### DIFF
--- a/AMApp/src/com/amapp/AMApplication.java
+++ b/AMApp/src/com/amapp/AMApplication.java
@@ -1,6 +1,7 @@
 package com.amapp;
 
 import com.amapp.common.AMServiceRequest;
+import com.androidquery.callback.BitmapAjaxCallback;
 import com.smart.framework.SmartApplication;
 
 /**
@@ -34,5 +35,13 @@ public class AMApplication extends SmartApplication {
         AMServiceRequest.getInstance().startFetchingNewSplashScreenFromServer();
         AMServiceRequest.getInstance().startQuoteOfTheWeekUpdatesFromServer();
         AMServiceRequest.getInstance().startNewsUpdatesFromServer();
+    }
+
+    @Override
+    public void onLowMemory(){
+        super.onLowMemory();
+        //clear all memory cached images when system is in low memory
+        //note that you can configure the max image cache count, see CONFIGURATION
+        BitmapAjaxCallback.clearCache();
     }
 }

--- a/AMApp/src/com/amapp/common/ImagePrefetchUtil.java
+++ b/AMApp/src/com/amapp/common/ImagePrefetchUtil.java
@@ -1,0 +1,21 @@
+package com.amapp.common;
+
+import android.widget.ImageView;
+
+import com.amapp.AMApplication;
+import com.smart.framework.SmartActivity;
+import com.smart.framework.SmartApplication;
+
+/**
+ * Created by dadesai on 1/5/16.
+ */
+public class ImagePrefetchUtil {
+
+    public static void prefetchImageFromCache(String url, int targetWidth) {
+        ImageView tempImage = new ImageView(AMApplication.getInstance().getApplicationContext());
+        SmartApplication.REF_SMART_APPLICATION.getAQuery().
+                id(tempImage).
+                image(url, true, true, targetWidth, 0);
+
+    }
+}

--- a/AMApp/src/com/amapp/thakorjitoday/TempleGalleryActivity.java
+++ b/AMApp/src/com/amapp/thakorjitoday/TempleGalleryActivity.java
@@ -15,8 +15,10 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 
 import com.amapp.AMAppMasterActivity;
+import com.amapp.AMApplication;
 import com.amapp.R;
 import com.amapp.common.TouchImageView;
+import com.androidquery.AQuery;
 import com.androidquery.callback.AjaxStatus;
 import com.androidquery.callback.BitmapAjaxCallback;
 import com.smart.caching.SmartCaching;
@@ -130,16 +132,20 @@ public class TempleGalleryActivity extends AMAppMasterActivity implements Consta
         public Object instantiateItem(ViewGroup container, final int position) {
             View itemView = LayoutInflater.from(TempleGalleryActivity.this).inflate(R.layout.temple_pager_item, container, false);
             final TouchImageView imgTemple= (TouchImageView) itemView.findViewById(R.id.imgAlbum);
+            AQuery aq = AMApplication.getInstance().getAQuery();
+
             if(position==0){
                 setViewTransitionName(imgTemple,"image");
             }
-            SmartApplication.REF_SMART_APPLICATION.getAQuery().id(imgTemple).image(images.get(position).getAsString("image"),true,true,getDeviceWidth(),0,new BitmapAjaxCallback(){
-                @Override
-                protected void callback(String url, ImageView iv, Bitmap bm, AjaxStatus status) {
-                    super.callback(url, iv, bm, status);
 
-                }
-            });
+            String imageUrl = images.get(position).getAsString("image");
+
+            // fetches the image from the network, if it's not in the local cache
+            // displays it on the screen using imgTemple object
+            aq.id(imgTemple)
+                    .progress(R.id.progress)
+                    .image(imageUrl, true, true, getDeviceWidth(), 0, null, AQuery.FADE_IN);
+
             container.addView(itemView);
             return itemView;
         }


### PR DESCRIPTION
This PR includes Perf Optimization for Thakorji Today image loading. It includes the changes below:

1) If device is running low on memory, flush out the cache
2) When user clicks on the mandir to view Thakorji images, prefetch **ALL** the images for that mandir in the memory from: 
* A) device local storage, if they were cached previously **OR**
* B) from the network. 

This way, by the time user is ready to scroll to image#2, image#3 and so on, the images will already be there in the memory
