### PR TITLE
Tech debt/crashlytics integration

### DIFF
--- a/AMApp/AndroidManifest.xml
+++ b/AMApp/AndroidManifest.xml
@@ -150,6 +150,9 @@
             </intent-filter>
         </receiver>
 
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="56524cff7b6347dadd24ae10f0510b7888edad9a" />
     </application>
 
 </manifest>

--- a/AMApp/build.gradle
+++ b/AMApp/build.gradle
@@ -1,4 +1,19 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.fabric.io/public' }
+    }
+
+    dependencies {
+        classpath 'io.fabric.tools:gradle:1.15.2'
+    }
+}
 apply plugin: 'android'
+apply plugin: 'io.fabric'
+
+repositories {
+    maven { url 'https://maven.fabric.io/public' }
+}
+
 apply plugin: 'com.google.gms.google-services'
 
 dependencies {
@@ -32,6 +47,9 @@ dependencies {
 //        transitive = true;
 //    }
     compile 'com.squareup:otto:1.3.8'
+    compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
+        transitive = true;
+    }
 }
 
 android {

--- a/AMApp/src/org/anoopam/main/AMApplication.java
+++ b/AMApp/src/org/anoopam/main/AMApplication.java
@@ -1,5 +1,7 @@
 package org.anoopam.main;
 
+import com.crashlytics.android.Crashlytics;
+import io.fabric.sdk.android.Fabric;
 import org.anoopam.main.common.AMServiceRequest;
 import org.anoopam.ext.smart.framework.SmartApplication;
 
@@ -26,6 +28,7 @@ public class AMApplication extends SmartApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+        Fabric.with(this, new Crashlytics());
         mEnvironment = Environment.ENV_LIVE;
         AMServiceRequest.getInstance().startHomeScreenTilesUpdatesFromServer();
     }

--- a/AMApp/src/org/anoopam/main/SplashActivity.java
+++ b/AMApp/src/org/anoopam/main/SplashActivity.java
@@ -24,6 +24,7 @@ import com.thin.downloadmanager.DownloadStatusListener;
 import org.anoopam.ext.smart.caching.SmartCaching;
 import org.anoopam.ext.smart.framework.SmartApplication;
 import org.anoopam.ext.smart.framework.SmartUtils;
+import org.anoopam.main.common.crashlytics.CrashlyticsUtils;
 import org.anoopam.main.home.HomeListActivity;
 
 import java.io.File;
@@ -67,8 +68,8 @@ public class SplashActivity extends AMAppMasterActivity {
         mLayout = (FrameLayout) findViewById(getLayoutID());
         splashImage = (ImageView) findViewById(R.id.splashscreen);
         setSplashScreenImage();
+        CrashlyticsUtils.crashlyticsLog("Started Splash Screen");
     }
-
 
     private void setSplashScreenImage() {
 

--- a/AMApp/src/org/anoopam/main/common/crashlytics/CrashlyticsUtils.java
+++ b/AMApp/src/org/anoopam/main/common/crashlytics/CrashlyticsUtils.java
@@ -1,5 +1,7 @@
 package org.anoopam.main.common.crashlytics;
 
+import com.crashlytics.android.Crashlytics;
+
 /**
  * Created by dadesai on 2/1/16.
  */
@@ -10,5 +12,13 @@ public class CrashlyticsUtils {
      */
     public static void forceCrash() {
         throw new RuntimeException("This is a Forced Crash for testing");
+    }
+
+    /***
+     * Logs the message in Crashlytics
+     * @param message
+     */
+    public static void crashlyticsLog(String message) {
+        Crashlytics.log(message);
     }
 }

--- a/AMApp/src/org/anoopam/main/common/crashlytics/CrashlyticsUtils.java
+++ b/AMApp/src/org/anoopam/main/common/crashlytics/CrashlyticsUtils.java
@@ -1,0 +1,14 @@
+package org.anoopam.main.common.crashlytics;
+
+/**
+ * Created by dadesai on 2/1/16.
+ */
+public class CrashlyticsUtils {
+
+    /**
+     * Force a crash
+     */
+    public static void forceCrash() {
+        throw new RuntimeException("This is a Forced Crash for testing");
+    }
+}

--- a/AMApp/src/org/anoopam/main/sahebjidarshan/SahebjiDarshanActivity.java
+++ b/AMApp/src/org/anoopam/main/sahebjidarshan/SahebjiDarshanActivity.java
@@ -22,6 +22,7 @@ import com.thin.downloadmanager.DownloadRequest;
 import com.thin.downloadmanager.DownloadStatusListener;
 
 import org.anoopam.ext.smart.caching.SmartCaching;
+import org.anoopam.main.common.crashlytics.CrashlyticsUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -100,6 +101,7 @@ public class SahebjiDarshanActivity extends AMAppMasterActivity {
         disableSideMenu();
         mSmartCaching = new SmartCaching(this);
         mSahebjiDarshanImage = (TouchImageView) findViewById(R.id.sahebji_darshan_image);
+        CrashlyticsUtils.crashlyticsLog("Sahebji Darshan Init");
     }
 
     @Override

--- a/AMApp/src/org/anoopam/main/thakorjitoday/TempleListActivity.java
+++ b/AMApp/src/org/anoopam/main/thakorjitoday/TempleListActivity.java
@@ -22,6 +22,7 @@ import org.anoopam.ext.smart.framework.SmartUtils;
 import org.anoopam.main.AMAppMasterActivity;
 import org.anoopam.main.R;
 import org.anoopam.main.common.AMServiceRequest;
+import org.anoopam.main.common.crashlytics.CrashlyticsUtils;
 import org.anoopam.main.common.events.EventBus;
 import org.anoopam.main.common.events.ThakorjiTodayUpdateFailedEvent;
 import org.anoopam.main.common.events.ThakorjiTodayUpdateSuccessEvent;
@@ -105,6 +106,7 @@ public class TempleListActivity extends AMAppMasterActivity {
         frmListFragmentContainer = (FrameLayout) findViewById(R.id.frmListFragmentContainer);
         templeListFragment = new TempleListFragment();
         smartCaching = new SmartCaching(this);
+        CrashlyticsUtils.crashlyticsLog("Thakorji Today Temple List Init");
     }
 
     @Override
@@ -160,7 +162,6 @@ public class TempleListActivity extends AMAppMasterActivity {
     }
 
     private void getCachedTemples() {
-
         SmartUtils.showProgressDialog(this, "Loading...", false);
         AsyncTask<Void, Void, ArrayList<ContentValues>> task = new AsyncTask<Void, Void,ArrayList<ContentValues>>() {
             @Override


### PR DESCRIPTION
PR includes:
* Crashlytics Integration - will help us get the info on App Crashes. 
* Crashlytics Util - static methods to help force crash, add crashlytics logs
* Crashlytics Logs - Use it to log into the Crashlytics logs bugger. e.g. you could add the logs to track the flow. So in-case if there is any app crash, along with reporting the stack trash, it would also log what the user was doing - depending on what we log in the code. This PR includes couple of Examples of logging
 